### PR TITLE
Fix padding(_)

### DIFF
--- a/src/area-label.js
+++ b/src/area-label.js
@@ -242,7 +242,8 @@ function areaLabel(area) {
   };
 
   my.padding = function(_) {
-    my.paddingX(_).paddingY(_);
+    my.paddingX(_)
+    my.paddingY(_);
   };
 
   if (area) {


### PR DESCRIPTION
As it currently stands, my. padding(_) returns an error of "Cannot read property 'paddingY' of undefined". 

my.padding(_) does the chain "my.paddingX(_).paddingY(_)"; however, "paddingX(_)" does not actually return anything like Left/Right/Top/Bottom does, and "paddingY(_)" cannot be called on undefined. 

My proposed solution is to separate "my.paddingX(_).paddingY(_)" into two separate calls "my.paddingX(_)" and "my.paddingY(_)".